### PR TITLE
Testnet4

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -26,7 +26,7 @@
  * Maximum amount of time that a block timestamp is allowed to exceed the
  * current time before the block will be accepted.
  */
-static constexpr int64_t MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60;
+static constexpr int64_t MAX_FUTURE_BLOCK_TIME = 20 * 60 * 60;
 
 /**
  * Timestamp window used as a grace period by code that compares external

--- a/src/chain.h
+++ b/src/chain.h
@@ -26,7 +26,7 @@
  * Maximum amount of time that a block timestamp is allowed to exceed the
  * current time before the block will be accepted.
  */
-static constexpr int64_t MAX_FUTURE_BLOCK_TIME = 20 * 60 * 60;
+static constexpr int64_t MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60;
 
 /**
  * Timestamp window used as a grace period by code that compares external

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -39,6 +39,10 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
         if (height % consensusParams.DifficultyAdjustmentInterval() == 0) {
             nNewTime = std::max<int64_t>(nNewTime, pindexPrev->GetBlockTime() - MAX_TIMEWARP);
         }
+        if ((consensusParams.fPowAllowMinDifficultyBlocks) && (!consensusParams.fPowNoRetargeting))
+        {
+            nNewTime = std::max<int64_t>(nNewTime, consensusParams.nPowTargetSpacing*2 + 1);
+        }
     }
 
     if (nOldTime < nNewTime) {
@@ -51,16 +55,6 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
     }
 
     return nNewTime - nOldTime;
-}
-
-int64_t UpdateTimeForTestnet(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
-{
-    int64_t nDiffTime = UpdateTime(pblock, consensusParams, pindexPrev);
-    int64_t nMinimalDiffTime = consensusParams.nPowTargetSpacing*2;
-    if ((consensusParams.fPowAllowMinDifficultyBlocks) && (nDiffTime <= nMinimalDiffTime)) {
-        nDiffTime = nMinimalDiffTime + 1;
-    }
-    return nDiffTime;    
 }
 
 void RegenerateCommitments(CBlock& block, ChainstateManager& chainman)

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -31,7 +31,7 @@ namespace node {
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     int64_t nOldTime = pblock->nTime;
-    int64_t nNewTime{std::max<int64_t>(pindexPrev->GetMedianTimePast() + 1, TicksSinceEpoch<std::chrono::seconds>(NodeClock::now()))};
+    int64_t nNewTime{std::max<int64_t>(pindexPrev->GetMedianTimePast() + 1, pindexPrev->GetBlockTime() + consensusParams.nPowTargetSpacing*2 + 1)};
 
     if (consensusParams.enforce_BIP94) {
         // Height of block to be mined.

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -34,7 +34,7 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
     int64_t nCurrentTime = TicksSinceEpoch<std::chrono::seconds>(NodeClock::now());
     int64_t nFutureTime = pindexPrev->GetBlockTime() + consensusParams.nPowTargetSpacing*2 + 1;
     int64_t nReplacedTime = std::max<int64_t>(nCurrentTime, nFutureTime);
-    if (pIndexPrev->nBits > 0x1d00ffff) {
+    if (pindexPrev->nBits > 0x1d00ffff) {
         nReplacedTime = nCurrentTime; //there is no need to replace time, if blocks are easier to mine than that
     }
     int64_t nNewTime{std::max<int64_t>(pindexPrev->GetMedianTimePast() + 1, nReplacedTime)};

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -34,10 +34,8 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
     int64_t nCurrentTime = TicksSinceEpoch<std::chrono::seconds>(NodeClock::now());
     int64_t nFutureTime = pindexPrev->GetBlockTime() + consensusParams.nPowTargetSpacing*2 + 1;
     int64_t nReplacedTime = std::max<int64_t>(nCurrentTime, nFutureTime);
-    if (pindexPrev->nBits > 0x1d00ffff) {
-        nReplacedTime = nCurrentTime; //there is no need to replace time, if blocks are easier to mine than that
-    }
-    int64_t nNewTime{std::max<int64_t>(pindexPrev->GetMedianTimePast() + 1, nReplacedTime)};
+    int64_t nTestnetTime = ((consensusParams.fPowAllowMinDifficultyBlocks) ? (nReplacedTime) : (nCurrentTime));
+    int64_t nNewTime{std::max<int64_t>(pindexPrev->GetMedianTimePast() + 1, nTestnetTime)};
 
     if (consensusParams.enforce_BIP94) {
         // Height of block to be mined.


### PR DESCRIPTION
<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

GUI-related pull requests should be opened against
https://github.com/bitcoin-core/gui
first. See CONTRIBUTING.md
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
